### PR TITLE
Webassembly bindings

### DIFF
--- a/sardine/Cargo.toml
+++ b/sardine/Cargo.toml
@@ -12,14 +12,14 @@ authors = ["Marc-André Moreau <marcandre.moreau@gmail.com>",
 
 [lib]
 name = "sardine"
-crate-type = ["staticlib", "lib"]
+crate-type = ["staticlib", "lib", "cdylib"]
 
 [dependencies]
 rand = "0.4"
 hmac = "0.6"
 sha2 = "0.7"
 digest = "0.7"
-wasm-bindgen = { version = "0.2.2", optional = true}
+wasm-bindgen = { version = "0.2", optional = true}
 
 num-bigint = {version = "0.1", default_features = false}
 num-traits = {version = "0.1", default_features = false}

--- a/sardine/Web.toml
+++ b/sardine/Web.toml
@@ -1,1 +1,0 @@
-default-target = "wasm32-unknown-unknown"

--- a/sardine/src/ffi.rs
+++ b/sardine/src/ffi.rs
@@ -96,7 +96,7 @@ pub extern "C" fn Srd_GetBlobName(srd_handle: *mut Srd, buffer: *mut u8, buffer_
     let srd = unsafe { &mut *srd_handle };
 
     if let Some(blob) = srd.get_raw_blob() {
-        let blob_type_len = blob.blob_type.len() as i32;
+        let blob_type_len = blob.blob_type().len() as i32;
         let blob_type_size = blob_type_len + 1;
 
         if buffer != std::ptr::null_mut() {
@@ -105,7 +105,7 @@ pub extern "C" fn Srd_GetBlobName(srd_handle: *mut Srd, buffer: *mut u8, buffer_
             }
 
             let buffer_data = unsafe { std::slice::from_raw_parts_mut::<u8>(buffer, buffer_size as usize) };
-            buffer_data[0..blob_type_len as usize].clone_from_slice(blob.blob_type.as_ref());
+            buffer_data[0..blob_type_len as usize].clone_from_slice(blob.blob_type().as_ref());
             buffer_data[blob_type_len as usize] = 0;
         }
 
@@ -120,7 +120,7 @@ pub extern "C" fn Srd_GetBlobData(srd_handle: *mut Srd, buffer: *mut u8, buffer_
     let srd = unsafe { &mut *srd_handle };
 
     if let Some(blob) = srd.get_raw_blob() {
-        let blob_data_len = (blob.data.len()) as i32;
+        let blob_data_len = (blob.data().len()) as i32;
 
         if buffer != std::ptr::null_mut() {
             if blob_data_len > buffer_size {
@@ -128,7 +128,7 @@ pub extern "C" fn Srd_GetBlobData(srd_handle: *mut Srd, buffer: *mut u8, buffer_
             }
 
             let buffer_data = unsafe { std::slice::from_raw_parts_mut::<u8>(buffer, buffer_size as usize) };
-            buffer_data.clone_from_slice(&blob.data);
+            buffer_data.clone_from_slice(&blob.data());
         }
 
         return blob_data_len;

--- a/sardine/src/lib.rs
+++ b/sardine/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "wasm", feature(proc_macro, wasm_custom_section, wasm_import_module))]
 extern crate aes_frast;
 extern crate byteorder;
 extern crate digest;
@@ -7,15 +8,17 @@ extern crate rand;
 extern crate sha2;
 
 #[cfg(feature = "wasm")]
+#[macro_use]
 extern crate wasm_bindgen;
 
 pub mod srd_blob;
 mod message_types;
-mod srd;
+pub mod srd;
 mod srd_errors;
 mod dh_params;
-pub mod ffi;
 
+#[cfg(not(feature = "wasm"))]
+pub mod ffi;
 pub type Result<T> = std::result::Result<T, srd_errors::SrdError>;
 pub use srd::Srd;
 pub use srd_errors::SrdError;

--- a/sardine/src/srd.rs
+++ b/sardine/src/srd.rs
@@ -162,7 +162,6 @@ impl Srd {
     }
 }
 
-// Private function
 impl Srd {
     pub fn get_blob<T: Blob>(&self) -> Result<Option<T>> {
         if self.blob.is_some() {

--- a/sardine/src/srd_blob/mod.rs
+++ b/sardine/src/srd_blob/mod.rs
@@ -12,18 +12,41 @@ mod logon_blob;
 pub use self::basic_blob::BasicBlob;
 pub use self::logon_blob::LogonBlob;
 
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::*;
+
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 pub struct SrdBlob {
-    pub blob_type: String,
-    pub data: Vec<u8>,
+    blob_type: String,
+    data: Vec<u8>,
 }
 
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 impl SrdBlob {
     pub fn new(blob_type: &str, data: &[u8]) -> SrdBlob {
         SrdBlob {
             blob_type: blob_type.to_string(),
             data: Vec::from(data),
         }
+    }
+
+    pub fn blob_type_copy(&self) -> String {
+        self.blob_type.clone()
+    }
+
+    pub fn data_copy(&self) -> Vec<u8> {
+        self.data.clone()
+    }
+}
+
+impl SrdBlob {
+    pub fn blob_type(&self) -> &str {
+        &self.blob_type
+    }
+
+    pub fn data(&self) -> &[u8] {
+        &self.data
     }
 }
 

--- a/sardine/wasm_build.sh
+++ b/sardine/wasm_build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cargo +nightly build --target wasm32-unknown-unknown --features "wasm" --release
+mkdir -p wasm
+wasm-bindgen --browser ../target/wasm32-unknown-unknown/release/sardine.wasm --out-dir ./wasm


### PR DESCRIPTION
Used wasm-bindgen to generate bindings for webassembly. Simply use the wasm_build.sh script to generate js, ts and wasm files in wasm/ folder.